### PR TITLE
Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configuration was added to enable Dependabot on our project. Dependabot is a tool that automatically checks our code dependencies for available updates. In this specific configuration, we've set Dependabot to check for updates to our Terraform modules on a weekly basis. Unfortunately, Dependabot does not currently support Shell script updates, so we cannot automate updates for that. With this configuration, we hope to keep our code safer and up-to-date, taking advantage of the latest improvements and fixes available for our Terraform dependencies.